### PR TITLE
1-flashed-data-are-never-removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Flashing a data will now correctly remove it next time you try to get it again.
+
 ## [0.1.0] 2020-09-11
 
 ### Added

--- a/src/Session.php
+++ b/src/Session.php
@@ -14,14 +14,7 @@ use OutOfRangeException;
  */
 class Session
 {
-    /**
-     * Keep track of flashed keys.
-     * Flashed keys are the keys of data that are flashed.
-     * A flashed data can only be getted once.
-     *
-     * @since 0.1.0
-     */
-    private static array $flashedKeys = [];
+    const FLASHED_KEYS_NAME = "__folded_flashed_keys";
 
     /**
      * Flash a data.
@@ -147,7 +140,7 @@ class Session
      */
     private static function addFlashedKey(string $key): void
     {
-        self::$flashedKeys[$key] = true;
+        $_SESSION[self::FLASHED_KEYS_NAME][$key] = true;
     }
 
     /**
@@ -201,6 +194,6 @@ class Session
      */
     private static function keyFlashed(string $key): bool
     {
-        return isset(self::$flashedKeys[$key]);
+        return isset($_SESSION[self::FLASHED_KEYS_NAME][$key]);
     }
 }


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when using `flashSession()` in a web context would not correctly remove the flashed data.

## Breaking

None.