### PR TITLE
3-throw-a-session-key-not-found-exception-instead-of-a-out-of-range-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- Using `getSession()` or `removeSession()` will now throw a `Folded\Exceptions\SessionKeyNotFoundException` instead of a `OutOfRangeException` if the key is not found in the session.
+
 ## [0.1.1] 2020-09-15
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.4.0"
+        "php": ">=7.4.0",
+        "folded/exception": "0.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f87d0a46d0195247fb0e8f22b456f680",
-    "packages": [],
+    "content-hash": "c2b0e995a34f72499a22c6c83ac2e6d0",
+    "packages": [
+        {
+            "name": "folded/exception",
+            "version": "v0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/folded-php/exception.git",
+                "reference": "0fd4c4230678d2b36ff7b37bb73fc1e11c9ee258"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/folded-php/exception/zipball/0fd4c4230678d2b36ff7b37bb73fc1e11c9ee258",
+                "reference": "0fd4c4230678d2b36ff7b37bb73fc1e11c9ee258",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "2.*",
+                "pestphp/pest": "0.3.*",
+                "phpunit/phpunit": "9.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Folded\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Khalyomede",
+                    "email": "khalyomede@gmail.com"
+                }
+            ],
+            "description": "Various kind of exception to throw for your web app.",
+            "time": "2020-09-18T17:22:08+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/semver",
@@ -4429,7 +4471,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=7.4.0"
+    },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Folded;
 
 use RuntimeException;
-use OutOfRangeException;
+use Folded\Exceptions\SessionKeyNotFoundException;
 
 /**
  * Represents values in the server session.
@@ -43,8 +43,8 @@ class Session
      * @param string $key  The name of the key associated with the value stored in session.
      * @param bool   $keep Wether to keep the value (useful if you flashed the data but need to keep it one more time).
      *
-     * @throws RuntimeException    If the session is not started.
-     * @throws OutOfRangeException If the session key is not found.
+     * @throws RuntimeException                              If the session is not started.
+     * @throws Folded\Exceptions\SessionKeyNotFoundException If the session key is not found.
      *
      * @since 0.1.0
      *
@@ -146,7 +146,7 @@ class Session
     /**
      * Throws an exception if the key is not in session.
      *
-     * @throws OutOfRangeException If the key is not found in session.
+     * @throws Folded\Exceptions\SessionKeyNotFoundException If the key is not found in session.
      *
      * @since 0.1.0
      *
@@ -157,7 +157,7 @@ class Session
     {
         if (!isset($_SESSION[$key])) {
             // @todo raise a SessionKeyNotFoundException instead
-            throw new OutOfRangeException("session key $key not found");
+            throw (new SessionKeyNotFoundException("session key $key not found"))->setKey($key);
         }
     }
 

--- a/src/getSession.php
+++ b/src/getSession.php
@@ -10,8 +10,8 @@ if (!function_exists("getSession")) {
      *
      * @param string $key The name of the key associated with the value stored in session.
      *
-     * @throws RuntimeException    If the session is not started.
-     * @throws OutOfRangeException If the session key is not found.
+     * @throws RuntimeException                              If the session is not started.
+     * @throws Folded\Exceptions\SessionKeyNotFoundException If the session key is not found.
      *
      * @since 0.1.0
      *

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types = 1);
 
 use Folded\Session;
+use Folded\Exceptions\SessionKeyNotFoundException;
 
 beforeEach(function (): void {
     if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -22,9 +23,19 @@ it("should set the session value in the key", function (): void {
 });
 
 it("should throw an exception if the session key is not found", function (): void {
-    $this->expectException(OutOfRangeException::class);
+    $this->expectException(SessionKeyNotFoundException::class);
 
     Session::get("not-found");
+});
+
+it("should set the session key in the exception if the session key is not found", function (): void {
+    $key = "not-found";
+
+    try {
+        Session::get($key);
+    } catch (SessionKeyNotFoundException $exception) {
+        expect($exception->getKey())->toBe($key);
+    }
 });
 
 it("should throw an exception message if the session key is not found", function (): void {
@@ -130,9 +141,19 @@ it("should remove the session key", function (): void {
 });
 
 it("should throw an exception if the session key is not found when removing the key", function (): void {
-    $this->expectException(OutOfRangeException::class);
+    $this->expectException(SessionKeyNotFoundException::class);
 
     Session::remove("not-found");
+});
+
+it("should set the session key in the exception if the session key is not found when removing the key", function (): void {
+    $key = "not-found";
+
+    try {
+        Session::remove($key);
+    } catch (SessionKeyNotFoundException $exception) {
+        expect($exception->getKey())->toBe($key);
+    }
 });
 
 it("should throw an exception message if the session key is not found when removing the key", function (): void {


### PR DESCRIPTION
## Added

None.

## Fixed

None.

## Breaking

- Using `getSession()` or `removeSession()` will now throw a `Folded\Exceptions\SessionKeyNotFoundException` instead of an `OutOfRangeException` when the key is not found.