### PR TITLE
6-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.2.0] 2020-09-22
 
 ### Breaking

--- a/src/flashSession.php
+++ b/src/flashSession.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("flashSession")) {
+if (!function_exists("Folded\flashSession")) {
     /**
      * Flash a data.
      * A flashed data can only be getted once.

--- a/src/getSession.php
+++ b/src/getSession.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getSession")) {
+if (!function_exists("Folded\getSession")) {
     /**
      * Get a value from the session.
      *

--- a/src/hasSession.php
+++ b/src/hasSession.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("hasSession")) {
+if (!function_exists("Folded\hasSession")) {
     /**
      * Returns true if the session has the value by its key, else returns false.
      *

--- a/src/removeSession.php
+++ b/src/removeSession.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("removeSession")) {
+if (!function_exists("Folded\removeSession")) {
     /**
      * Removes a value by its key in the session.
      *

--- a/src/setSession.php
+++ b/src/setSession.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setSession")) {
+if (!function_exists("Folded\setSession")) {
     /**
      * Set the value in the session.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Added missing `Folded` namespace in `function_exists` statements.

## Breaking

None.